### PR TITLE
start playing with panel

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,9 +1,10 @@
-name: dask-tutorial
+name: dask-tutorial-panel
 channels:
   - conda-forge
 dependencies:
   - python==3.10
-  - dask
+  - dask==2022.12.0
+  - distributed==2022.12.0
   - coiled
   - pyarrow
   - ipykernel
@@ -14,6 +15,5 @@ dependencies:
   - holoviews
   - hvplot
   - python-graphviz
-  - pip
   - pip:
-    - git+https://github.com/mrocklin/distributed@pydata-nyc-2022
+     - panel


### PR DESCRIPTION
Goal:

- expose the interactive datashader map of NYC taxi data as a Panel (https://panel.holoviz.org/) application

Where I am now:

- `panel serve 2-dataframes-at-scale.ipynb --show` runs a panel application showing (just to make iteration faster for now) a subset of the data using a LocalCluster

Where I'm stuck:

- if I load the application in multiple tabs and play with it in both, I get `ValueError: Inputs contain futures that were created by another client.` and all but one of the tabs are broken

In the real deployment I'd hope to use the same cluster, but this is happening even with each browser tab independently launching a separate dask LocalCluster.

I guess something in Datashader or Panel or the interaction isn't thread-safe maybe? I don't really know anything about how Panel or Datashader work.

Next steps if I get past this:

- switch to a Coiled cluster w/ bigger data
- learn how to use `pn.state.cache` to cache some shared state (e.g. a reference to the cluster, and how to find the already-loaded dataset in the cluster)
- deploy it somewhere